### PR TITLE
encode the final_service_name instead of decode

### DIFF
--- a/capirca/lib/paloaltofw.py
+++ b/capirca/lib/paloaltofw.py
@@ -144,7 +144,7 @@ class Service(object):
             "You have a duplicate service. A service named %s already exists." %
             str(final_service_name))
 
-    if len(final_service_name.decode("utf-8")) > 63:
+    if len(final_service_name.encodedecode("utf-8")) > 63:
       raise PaloAltoFWTooLongName("Service name must be 63 characters max: %s" %
                                   str(final_service_name))
     self.service_map[(ports, protocol)] = {"name": final_service_name}


### PR DESCRIPTION
paloaltofw.py try to decode a string : 

     if len(final_service_name.decode("utf-8","ignore")) > 63:
        raise PaloAltoFWTooLongName("Service name must be 63 characters max: %s" %
                                                             str(final_service_name))`
trackbacks

     File "/home/aaqrabaw/PycharmProjects/google/capirca/lib/paloaltofw.py", line 165, in __init__
        self.ModifyOptions(terms)
      File "/home/aaqrabaw/PycharmProjects/google/capirca/lib/paloaltofw.py", line 221, in ModifyOptions
        unused_new_service = Service(ports, term.name, p)
      File "/home/aaqrabaw/PycharmProjects/google/capirca/lib/paloaltofw.py", line 146, in __init__
        if len(final_service_name.decode("utf-8","ignore")) > 63:
    AttributeError: 'str' object has no attribute 'decode'